### PR TITLE
fix manifest properties in pwa deploy

### DIFF
--- a/.github/workflows/publish-pwa.yaml
+++ b/.github/workflows/publish-pwa.yaml
@@ -53,6 +53,18 @@ jobs:
         run: |
           cd apicurito/ui/dist
           sed -i  "6s/\//\/apicurito\/pwa\//g" index.html
+      - name: Fix Manifest Scope
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: apicurito/ui/dist/manifest.json
+          field: scope
+          value: /apicurito/pwa
+      - name: Fix Manifest Start Url
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: apicurito/ui/dist/manifest.json
+          field: start_url
+          value: /apicurito/pwa
       - name: Copy PWA to Website
         run: |
           cd apicurito/ui


### PR DESCRIPTION
This fixes the issue described in: https://github.com/Apicurio/apicurito/pull/119#issuecomment-717619035

We modify the `manifest.json` file's `scope` and `start_url` properties before copying the `dist` directory to the site.

As usual I spoke too soon and should have just read your deploy code - I see you're already doing something similar to fix the base href in the `index.html` file so this was an easy addition.

I haven't been able to test this since it only runs on master though.