### PR TITLE
ENTESB-15631: Adds kustomize install process for operator

### DIFF
--- a/operator/kustomize/.gitignore
+++ b/operator/kustomize/.gitignore
@@ -1,0 +1,3 @@
+**/*.yml
+**/release/apicurito-*
+**/release/*.tar.gz

--- a/operator/kustomize/Makefile
+++ b/operator/kustomize/Makefile
@@ -1,0 +1,47 @@
+#
+# Make Options
+#
+MK_OPTIONS := -s
+
+#
+# Vars
+#
+
+#
+# Vars that can be overridden by external env vars
+#
+KUBE_USER ?= developer
+
+.PHONY: kustomize setup operator app product
+
+kubectl:
+ifeq (, $(shell which kubectl))
+$(error "No kubectl found in PATH. Please install and re-run")
+endif
+
+#
+# Setup the installation by installing crds, roles and granting
+# privileges for the installing user.
+#
+setup: kubectl
+	$(MAKE) $(MK_OPTIONS) -C bases/crd
+	$(MAKE) $(MK_OPTIONS) -C bases/role
+	#@ Must be invoked by a user with cluster-admin privileges
+	kubectl apply -k setup
+
+#
+# Install the operator deployment and related resources
+#
+operator: kubectl
+	$(MAKE) $(MK_OPTIONS) -C bases/deployment
+	#@ Must be invoked by a user previously granted permissions using `KUBE_USER=<user> make install-setup`
+	kubectl apply -k operator
+
+#
+# Installs the operator deployment and in addition installs a default CR
+#
+app: kubectl
+	$(MAKE) $(MK_OPTIONS) -C bases/deployment
+	$(MAKE) $(MK_OPTIONS) -C app
+	#@ Must be invoked by a user previously granted permissions using `KUBE_USER=<user> make install-setup`
+	kubectl apply -k app

--- a/operator/kustomize/app/Makefile
+++ b/operator/kustomize/app/Makefile
@@ -1,0 +1,10 @@
+ASSETS := ../../deploy
+APP := ./apicurio-cr.yml
+
+.PHONY: sync
+
+#
+# Copy the deploy template from the deploy directory
+#
+sync:
+	cp $(ASSETS)/cr.yaml $(APP)

--- a/operator/kustomize/app/kustomization.yaml
+++ b/operator/kustomize/app/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+- ../operator
+resources:
+- ./apicurio-cr.yml
+commonLabels:
+  app: apicurito

--- a/operator/kustomize/bases/crd/Makefile
+++ b/operator/kustomize/bases/crd/Makefile
@@ -1,0 +1,10 @@
+ASSETS := ../../../deploy
+CRD := ./crd.yml
+
+.PHONY: sync
+
+#
+# Copy the deploy template from the deploy directory
+#
+sync:
+	cp $(ASSETS)/crd.yaml $(CRD)

--- a/operator/kustomize/bases/crd/kustomization.yaml
+++ b/operator/kustomize/bases/crd/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- crd.yml

--- a/operator/kustomize/bases/deployment/Makefile
+++ b/operator/kustomize/bases/deployment/Makefile
@@ -1,0 +1,10 @@
+ASSETS := ../../../deploy
+DEPLOYMENT := ./deployment.yml
+
+.PHONY: sync
+
+#
+# Copy the deploy template from the deploy directory
+#
+sync:
+	cp $(ASSETS)/operator.yaml $(DEPLOYMENT)

--- a/operator/kustomize/bases/deployment/kustomization.yaml
+++ b/operator/kustomize/bases/deployment/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- deployment.yml

--- a/operator/kustomize/bases/role/Makefile
+++ b/operator/kustomize/bases/role/Makefile
@@ -1,0 +1,15 @@
+ASSETS := ../../../deploy
+RBAC := ./rbac.yml
+RBAC_USER := ./rbac-user.yml
+
+KUBE_USER ?= developer
+
+.PHONY: sync
+
+#
+# Copy the deploy template from the deploy directory
+#
+sync:
+	cp $(ASSETS)/rbac.yaml $(RBAC)
+	cp ./rbac-user.yaml $(RBAC_USER)
+	sed -i 's/{{.User}}/$(KUBE_USER)/' $(RBAC_USER)

--- a/operator/kustomize/bases/role/kustomization.yaml
+++ b/operator/kustomize/bases/role/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- rbac.yml
+- rbac-user.yml

--- a/operator/kustomize/bases/role/rbac-user.yaml
+++ b/operator/kustomize/bases/role/rbac-user.yaml
@@ -1,0 +1,24 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: apicurito-operator-installer
+rules:
+- apiGroups:
+  - "apicur.io"
+  resources:
+  - "*"
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: apicurito-operator-{{.User}}-installer
+subjects:
+- kind: User
+  name: {{.User}}
+roleRef:
+  kind: Role
+  name: apicurito-operator-installer
+  apiGroup: rbac.authorization.k8s.io

--- a/operator/kustomize/operator/kustomization.yaml
+++ b/operator/kustomize/operator/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../bases/deployment
+commonLabels:
+  app: apicurito

--- a/operator/kustomize/release/Makefile
+++ b/operator/kustomize/release/Makefile
@@ -1,0 +1,44 @@
+
+VERSION := 1.0.0
+
+#
+# Make Options
+#
+MK_OPTIONS := -s
+
+.PHONY: $(SUBDIRS)
+
+SYNCDIRS := ../app ../bases/crd ../bases/deployment ../bases/grant ../bases/role
+
+sync:
+	for dir in $(SYNCDIRS); do \
+    $(MAKE) $(MK_OPTIONS) -C $$dir; \
+  done
+
+INSTALLDIR := apicurito-install
+RELEASEDIRS := ../app ../bases ../operator ../setup
+
+create:
+	#@ Make a new apicurito builddirectory
+	mkdir -p $(INSTALLDIR)
+	#@ Copy directories into build directory
+	for dir in $(RELEASEDIRS); do \
+    cp -rf $$dir $(INSTALLDIR)/; \
+  done
+	#@ Remove sync rules from Makefiles
+	for f in `find $(INSTALLDIR) -name Makefile`; do \
+		echo -e "sync:\n  #@ Not required in release" > $$f; \
+	done
+	#@ Copy the root Makefile into build directory
+	cp -f ../Makefile $(INSTALLDIR)/
+
+release: sync create
+ifndef VERSION
+	$(error VERSION is not set)
+endif
+	tar zcvf apicurito-install-release-$(VERSION).tar.gz $(INSTALLDIR)
+	#@ Hand off to the release script
+	./release.sh $(VERSION)
+
+clean:
+	rm -rf apicurito *.tar.gz

--- a/operator/kustomize/release/release.sh
+++ b/operator/kustomize/release/release.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+# Save global script args
+ARGS=("$@")
+
+# Exit if any error occurs
+# Fail on a single failed command in a pipeline (if supported)
+set -o pipefail
+
+# Fail on error and undefined vars (please don't use global vars, but evaluation of functions for return values)
+set -eu
+
+# Helper functions
+
+# Dir where this script is located
+basedir() {
+    # Default is current directory
+    local script=${BASH_SOURCE[0]}
+
+    # Resolve symbolic links
+    if [ -L $script ]; then
+        if readlink -f $script >/dev/null 2>&1; then
+            script=$(readlink -f $script)
+        elif readlink $script >/dev/null 2>&1; then
+            script=$(readlink $script)
+        elif realpath $script >/dev/null 2>&1; then
+            script=$(realpath $script)
+        else
+            echo "ERROR: Cannot resolve symbolic link $script"
+            exit 1
+        fi
+    fi
+
+    local dir=$(dirname "$script")
+    local full_dir=$(cd "${dir}" && pwd)
+    echo ${full_dir}
+}
+
+# Checks if a flag is present in the arguments.
+hasflag() {
+    filters="$@"
+    for var in "${ARGS[@]:-}"; do
+        for filter in $filters; do
+          if [ "$var" = "$filter" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+}
+
+# Read the value of an option.
+readopt() {
+    filters="$@"
+    next=false
+    for var in "${ARGS[@]:-}"; do
+        if $next; then
+            echo $var
+            break;
+        fi
+        for filter in $filters; do
+            if [[ "$var" = ${filter}* ]]; then
+                local value="${var//${filter}=/}"
+                if [ "$value" != "$var" ]; then
+                    echo $value
+                    return
+                fi
+                next=true
+            fi
+        done
+    done
+}
+
+# Getting base dir
+BASEDIR=$(basedir)
+RELEASE_GIT_ORG="apicurio"
+RELEASE_GIT_REPO="apicurito"
+TAR_NAME="apicurito-install-release"
+
+get_github_username() {
+    if [ -z "${GITHUB_USERNAME:-}" ]; then
+        echo "ERROR: environment variable GITHUB_USERNAME has not been set."
+        echo "Please populate it with your github id"
+        return
+    fi
+    echo $GITHUB_USERNAME
+}
+
+get_github_access_token() {
+    if [ -z "${GITHUB_ACCESS_TOKEN:-}" ]; then
+        echo "ERROR: environment variable GITHUB_ACCESS_TOKEN has not been set."
+        echo "Please populate it with a valid personal access token from github (with 'repo', 'admin:org_hook' and 'admin:repo_hook' scopes)."
+        return
+    fi
+    echo $GITHUB_ACCESS_TOKEN
+}
+
+check_error() {
+  local msg="$*"
+  if [ "${msg//ERROR/}" != "${msg}" ]; then
+    echo $msg
+    exit 1
+  fi
+}
+
+publish_artifact() {
+  if [ -z ${VERSION} ]; then
+    check_error "Error: Version not defined"
+  fi
+
+  local release_file="${TAR_NAME}-${VERSION}"
+  local github_url="https://api.github.com/repos/${RELEASE_GIT_ORG}/${RELEASE_GIT_REPO}/releases"
+
+  set +e
+  local upload_url=$(\
+    curl -q --fail -X POST \
+      -u $GITHUB_USERNAME:${GITHUB_ACCESS_TOKEN} \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Content-Type: application/json" \
+      -d "{\"tag_name\": \"${release_file}\"}" \
+      ${github_url} | \
+      jq -r .upload_url | cut -d{ -f1)
+
+  if [[ ! $upload_url == http* ]]; then
+    echo "ERROR: Cannot create release on remote github repository. Check if a release with the same tag already exists."
+    return
+  fi
+  set -e
+
+  if [ ! -f "${release_file}.tar.gz" ]; then
+    echo "ERROR: Cannot find release tar archive in current directory"
+    return
+  fi
+
+  set +e
+  curl -q --fail -X POST -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Content-Type: application/tar+gzip" \
+    --data-binary "@${release_file}.tar.gz" \
+    ${upload_url}?name="${release_file}.tar.gz"
+  local err=$?
+  set -e
+
+  if [ $err -ne 0 ]; then
+    echo "ERROR: Cannot upload release artifact ${release_file}.tar.gz on remote github repository"
+    return
+  fi
+}
+
+release_tar() {
+  local github_username=$(get_github_username)
+  check_error $github_username
+
+  local github_token=$(get_github_access_token)
+  check_error $github_token
+
+  result=$(publish_artifact)
+  check_error $result
+}
+
+release() {
+  if [ -z ${VERSION} ]; then
+    check_error "Error: Version not defined"
+  fi
+
+  local release_file="${TAR_NAME}-${VERSION}"
+
+  echo "=== Tagging ${release_file}"
+  git tag -f "${release_file}"
+
+  # Push release tag
+  local remote="git@github.com:${RELEASE_GIT_ORG}/${RELEASE_GIT_REPO}.git"
+  git push ${remote} ${release_file}
+
+  echo "==== Releasing tar file"
+  release_tar
+}
+
+
+# ==========================================================================================
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <version>"
+    exit 1
+fi
+
+VERSION="${1}"
+release

--- a/operator/kustomize/setup/kustomization.yaml
+++ b/operator/kustomize/setup/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../bases/crd
+- ../bases/role
+commonLabels:
+  app: apicurito


### PR DESCRIPTION
* Everything within single kustomize directory

* Makefile at root provides command structure:
 ** As cluster-admin -> make setup => install crd, roles, grants
 ** As user -> make operator / app => install operator & optionally CR

* bases
 * The holistic base kustomizations, copied from the main codebase to
   create *.yml files

* app / setup / operator
 * Overlays that bring in different bases and add extra resources

* release
 * For releasing kustomize directory as single tar archive for direct
   download for users (save having to clone repository)